### PR TITLE
dhcp: Increasing test coverage for DHCP responses

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -79,3 +79,15 @@ func TestServeDHCPValidRequest_OK(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestServeDHCPRelease_OK(t *testing.T) {
+	dhcpServer := newDHCPServer()
+	p := dhcp.NewPacket(dhcp.BootReply)
+	// Request the IP from the DHCP Server
+	p.SetCIAddr(net.ParseIP("172.10.0.2"))
+
+	expected := dhcp.Packet(nil)
+	actual := dhcpServer.ServeDHCP(p, dhcp.Release, nil)
+
+	assert.Equal(t, expected, actual)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -34,15 +34,24 @@ func TestFreeLease_OK(t *testing.T) {
 	assert.NotEqual(t, NotExpected, actual)
 }
 
-func TestServeDHCP(t *testing.T) {
+func TestServeDHCPDiscover_OK(t *testing.T) {
 	dhcpServer := newDHCPServer()
-	p := dhcp.NewPacket(dhcp.BootReply)
 
-	expected := dhcp.ReplyPacket(p, dhcp.Offer, dhcpServer.ip,
+	expected := dhcp.ReplyPacket(dhcp.NewPacket(dhcp.BootReply), dhcp.Offer, dhcpServer.ip,
 		dhcp.IPAdd(dhcpServer.start, dhcpServer.freeLease()),
 		dhcpServer.leaseDuration, dhcpServer.options.SelectOrderOrAll(nil))
-	actual := dhcpServer.ServeDHCP(p, dhcp.Discover, nil)
+	actual := dhcpServer.ServeDHCP(dhcp.NewPacket(dhcp.BootReply), dhcp.Discover, nil)
 
-	//TODO: Need a strong assertion
-	assert.ObjectsAreEqual(actual, expected)
+	// TODO: Need a strong assertion
+	// See Issue: https://github.com/simar7/xserver/issues/8
+	assert.ObjectsAreEqual(expected, actual)
+}
+
+func TestServeDHCPInvalidRequest_OK(t *testing.T) {
+	dhcpServer := newDHCPServer()
+
+	expected := dhcp.ReplyPacket(dhcp.NewPacket(dhcp.BootReply), dhcp.NAK, dhcpServer.ip, nil, 0, nil)
+	actual := dhcpServer.ServeDHCP(dhcp.NewPacket(dhcp.BootReply), dhcp.Request, dhcpServer.options)
+
+	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
This PR adds the following:

- [x] Unit test for DHCP Request (Invalid Request)
- [x] Unit test for DHCP Request (Valid Request)
- [x] Unit test for DHCP Release and Decline
- [x] Better logging with logutils.

Signed-off-by: Simarpreet Singh <simar@linux.com>